### PR TITLE
Dry run mode

### DIFF
--- a/src/clickhouse_migrations/clickhouse_cluster.py
+++ b/src/clickhouse_migrations/clickhouse_cluster.py
@@ -55,6 +55,7 @@ class ClickhouseCluster:
         cluster: Optional[str] = None,
         create_db_if_no_exists: bool = True,
         multi_statement: bool = True,
+        dryrun: bool = False
     ):
         storage = MigrationStorage(migration_path)
         migrations = storage.migrations()
@@ -65,6 +66,7 @@ class ClickhouseCluster:
             migrations,
             create_db_if_no_exists=create_db_if_no_exists,
             multi_statement=multi_statement,
+            dryrun=dryrun
         )
 
     def apply_migrations(
@@ -72,6 +74,7 @@ class ClickhouseCluster:
         db_name: str,
         cluster: Optional[str],
         migrations: List[Migration],
+        dryrun: bool = False,
         create_db_if_no_exists: bool = True,
         multi_statement: bool = True,
     ) -> List[Migration]:
@@ -80,6 +83,6 @@ class ClickhouseCluster:
             self.create_db(db_name)
 
         with self.connection(db_name) as conn:
-            migrator = Migrator(conn)
+            migrator = Migrator(conn, dryrun)
             migrator.init_schema(cluster)
             return migrator.apply_migration(migrations, multi_statement)

--- a/src/clickhouse_migrations/clickhouse_cluster.py
+++ b/src/clickhouse_migrations/clickhouse_cluster.py
@@ -59,7 +59,7 @@ class ClickhouseCluster:
         cluster_name: Optional[str] = None,
         create_db_if_no_exists: bool = True,
         multi_statement: bool = True,
-        dryrun: bool = False
+        dryrun: bool = False,
     ):
         storage = MigrationStorage(migration_path)
         migrations = storage.migrations()
@@ -70,7 +70,7 @@ class ClickhouseCluster:
             cluster_name=cluster_name,
             create_db_if_no_exists=create_db_if_no_exists,
             multi_statement=multi_statement,
-            dryrun=dryrun
+            dryrun=dryrun,
         )
 
     def apply_migrations(

--- a/src/clickhouse_migrations/cmd.py
+++ b/src/clickhouse_migrations/cmd.py
@@ -85,6 +85,12 @@ def get_context(args):
         type=cluster,
         help="Clickhouse topology cluster"
     )
+    parser.add_argument(
+        "--dry-run",
+        default=os.environ.get("DRY_RUN", "0"),
+        type=bool,
+        help="Dry run mode"
+    )
 
     return parser.parse_args(args)
 
@@ -98,7 +104,7 @@ def migrate(ctx) -> int:
         db_user=ctx.db_user,
         db_password=ctx.db_password,
     )
-    cluster.migrate(db_name=ctx.db_name, migration_path=ctx.migrations_dir, cluster=ctx.cluster, multi_statement=ctx.multi_statement)
+    cluster.migrate(db_name=ctx.db_name, migration_path=ctx.migrations_dir, cluster=ctx.cluster, multi_statement=ctx.multi_statement, dryrun=ctx.dry_run)
     return 0
 
 

--- a/src/clickhouse_migrations/cmd.py
+++ b/src/clickhouse_migrations/cmd.py
@@ -89,13 +89,7 @@ def get_context(args):
         "--dry-run",
         default=os.environ.get("DRY_RUN", "0"),
         type=bool,
-        help="Dry run mode"
-    )
-    parser.add_argument(
-        "--dry-run",
-        default=os.environ.get("DRY_RUN", "0"),
-        type=bool,
-        help="Dry run mode"
+        help="Dry run mode",
     )
 
     return parser.parse_args(args)

--- a/src/clickhouse_migrations/migrator.py
+++ b/src/clickhouse_migrations/migrator.py
@@ -8,8 +8,9 @@ from clickhouse_migrations.types import Migration
 
 
 class Migrator:
-    def __init__(self, conn: Client):
+    def __init__(self, conn: Client, dryrun: bool = False):
         self._conn: Client = conn
+        self._dryrun = dryrun
 
     def init_schema(self, cluster: Optional[str]):
         cluster_schema = \
@@ -109,20 +110,23 @@ ORDER BY tuple(created_at)"""
 
             logging.info("Migration contains %s statements to apply", len(statements))
             for statement in statements:
-                self._execute(statement)
+                if not self._dryrun:
+                    self._execute(statement)
+                else:
+                    logging.info("Dry run mode, would have executed: %s", statement)
 
             logging.info("Migration applied, need to update schema version table.")
-
-            self._execute(
-                "INSERT INTO schema_versions(version, script, md5) VALUES",
-                [
-                    {
-                        "version": migration.version,
-                        "script": migration.script,
-                        "md5": migration.md5,
-                    }
-                ],
-            )
+            if not self._dryrun:
+                self._execute(
+                    "INSERT INTO schema_versions(version, script, md5) VALUES",
+                    [
+                        {
+                            "version": migration.version,
+                            "script": migration.script,
+                            "md5": migration.md5,
+                        }
+                    ],
+                )
 
             logging.info("Migration is fully applied.")
 

--- a/src/tests/test_dryrun.py
+++ b/src/tests/test_dryrun.py
@@ -1,0 +1,70 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from clickhouse_migrations.clickhouse_cluster import ClickhouseCluster
+from clickhouse_migrations.types import MigrationStorage
+
+TESTS_DIR = Path(__file__).parent
+MIGRATIONS = MigrationStorage(TESTS_DIR / "migrations").migrations()
+
+
+@pytest.fixture
+def cluster():
+    return ClickhouseCluster("localhost", "default", "")
+
+
+@pytest.fixture(name="_clean_slate")
+def clean_slate(cluster):
+    with cluster.connection("") as conn:
+        conn.execute("DROP DATABASE IF EXISTS pytest ON CLUSTER company_cluster")
+
+
+@pytest.fixture(name="_schema")
+def schema(cluster, _clean_slate):
+    conn = cluster.connection("")
+    conn.execute("CREATE DATABASE pytest ON CLUSTER company_cluster")
+    conn = cluster.connection("pytest")
+    cluster.init_schema("pytest")
+
+    return conn
+
+
+def test_dryrun(_schema, cluster, caplog):
+    with caplog.at_level(logging.INFO):
+        cluster.migrate("pytest", TESTS_DIR / "migrations", dryrun=True)
+
+        with cluster.connection("pytest") as conn:
+            assert (
+                conn.execute("SELECT count(*) FROM pytest.schema_versions")[0][0] == 0
+            )
+
+            assert (
+                conn.execute(
+                    "SELECT count(*) FROM system.tables WHERE database = 'pytest' AND name = 'sample'"
+                )[0][0]
+                == 0
+            )
+
+    assert f"Dry run mode, would have executed: {MIGRATIONS[0].script}" in caplog.text
+
+
+def test_not_dryrun(_schema, cluster, caplog):
+    with caplog.at_level(logging.INFO):
+        cluster.migrate("pytest", TESTS_DIR / "migrations", dryrun=False)
+
+        with cluster.connection("pytest") as conn:
+            assert (
+                conn.execute("SELECT count(*) FROM pytest.schema_versions")[0][0] == 1
+            )
+            assert (
+                conn.execute(
+                    "SELECT count(*) FROM system.tables WHERE database = 'pytest' AND name = 'sample'"
+                )[0][0]
+                == 1
+            )
+
+    assert (
+        f"Dry run mode, would have executed: {MIGRATIONS[0].script}" not in caplog.text
+    )


### PR DESCRIPTION
Support dry run mode where migrations aren't actually executed, instead sql of migrations that would have been executed is logged.

FYI, this will probably be my last PR for a while