### PR TITLE
Add CLI argument --create-if-not-exists

### DIFF
--- a/src/clickhouse_migrations/command_line.py
+++ b/src/clickhouse_migrations/command_line.py
@@ -125,6 +125,13 @@ def get_context(args):
         action=argparse.BooleanOptionalAction,
         help="Use secure connection",
     )
+    parser.add_argument(
+        "--create-db-if-not-exists",
+        default=cast_to_bool(os.environ.get("CREATE_DB_IF_NOT_EXISTS", "1")),
+        type=bool,
+        action=argparse.BooleanOptionalAction,
+        help="Create database if it does not exist",
+    )
 
     return parser.parse_args(args)
 
@@ -146,6 +153,7 @@ def do_migrate(cluster, ctx) -> List[Migration]:
         migration_path=ctx.migrations_dir,
         explicit_migrations=ctx.migrations,
         cluster_name=ctx.cluster_name,
+        create_db_if_no_exists=ctx.create_db_if_not_exists,
         multi_statement=ctx.multi_statement,
         dryrun=ctx.dry_run,
         fake=ctx.fake,

--- a/src/tests/test_command_line.py
+++ b/src/tests/test_command_line.py
@@ -32,3 +32,14 @@ def test_check_fake_ok():
         ]
     )
     assert context.fake is False
+
+
+def test_check_create_db_if_not_exists_ok():
+    context = get_context([])
+    assert context.create_db_if_not_exists is True
+
+    context = get_context(["--create-db-if-not-exists"])
+    assert context.create_db_if_not_exists is True
+
+    context = get_context(["--no-create-db-if-not-exists"])
+    assert context.create_db_if_not_exists is False


### PR DESCRIPTION
Expose the argument of `cluster.migrate` function in CLI.