### PR TITLE
Prepare release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.10.0](https://github.com/zifter/clickhouse-migrations/tree/v0.10.0) (2026-04-19)
+
+[Full Changelog](https://github.com/zifter/clickhouse-migrations/compare/v0.9.1...v0.10.0)
+
+**What's Changed:**
+- Add Python 3.14 support. Done by @zifter
+- Improve README: fix typos, add migration example, document all parameters. Done by @zifter in https://github.com/zifter/clickhouse-migrations/pull/41
+- Add star history chart to README. Done by @zifter in https://github.com/zifter/clickhouse-migrations/pull/42
+
+
 ## [v0.8.0](https://github.com/zifter/clickhouse-migrations/tree/v0.8.0) (2024-08-18)
 
 [Full Changelog](https://github.com/zifter/clickhouse-migrations/compare/v0.7.1...v0.8.0)

--- a/src/clickhouse_migrations/__init__.py
+++ b/src/clickhouse_migrations/__init__.py
@@ -2,4 +2,4 @@
 Simple file-based migrations for clickhouse
 """
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"


### PR DESCRIPTION
## Summary
- Bump version to `0.10.0` in `__init__.py`
- Add CHANGELOG entry for v0.10.0

## What's in this release
- Add Python 3.14 support
- Improve README: fix typos, add migration example, document all parameters (#41)
- Add star history chart to README (#42)

## Test plan
- [ ] CI passes
- [ ] Merge, then tag `v0.10.0` to trigger PyPI release

🤖 Generated with [Claude Code](https://claude.com/claude-code)