### PR TITLE
Add compact migration log format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ CLI flag | Environment variable | Default
 `--fake` | `FAKE` | `false`
 `--secure` | `SECURE` | `false`
 `--log-level` | `LOG_LEVEL` | `WARNING`
+`--migration-log-format` | `MIGRATION_LOG_FORMAT` | `full`
 
 ### In code
 ```python
@@ -103,6 +104,7 @@ cluster.migrate(
     multi_statement=True,
     dryrun=False,
     fake=False,
+    migration_log_format="full",
 )
 ```
 
@@ -128,6 +130,7 @@ Parameter | Description | Default
 `dryrun` | Print migrations without executing them | `False`
 `fake` | Mark migrations as applied without executing SQL | `False`
 `secure` | Use secure (TLS) connection | `False`
+`migration_log_format` | Migration log format `full` logs the full Migration object, `compact` logs only version and md5 | `full`
 
 ### Notes
 The ClickHouse driver does not natively support executing multiple statements in a single query.

--- a/src/clickhouse_migrations/clickhouse_cluster.py
+++ b/src/clickhouse_migrations/clickhouse_cluster.py
@@ -94,6 +94,7 @@ class ClickhouseCluster:
         dryrun: bool = False,
         explicit_migrations: Optional[List[str]] = None,
         fake: bool = False,
+        migration_log_format: str = "full",
     ):
         db_name = db_name if db_name is not None else self.default_db_name
 
@@ -108,6 +109,7 @@ class ClickhouseCluster:
             multi_statement=multi_statement,
             dryrun=dryrun,
             fake=fake,
+            migration_log_format=migration_log_format,
         )
 
     def apply_migrations(
@@ -119,6 +121,7 @@ class ClickhouseCluster:
         create_db_if_no_exists: bool = True,
         multi_statement: bool = True,
         fake: bool = False,
+        migration_log_format: str = "full",
     ) -> List[Migration]:
         if create_db_if_no_exists:
             if cluster_name is None:
@@ -127,6 +130,6 @@ class ClickhouseCluster:
                 self.create_db(db_name, cluster_name)
 
         with self.connection(db_name) as conn:
-            migrator = Migrator(conn, dryrun)
+            migrator = Migrator(conn, dryrun, migration_log_format=migration_log_format)
             migrator.init_schema(cluster_name)
             return migrator.apply_migration(migrations, multi_statement, fake=fake)

--- a/src/clickhouse_migrations/command_line.py
+++ b/src/clickhouse_migrations/command_line.py
@@ -15,7 +15,7 @@ from clickhouse_migrations.defaults import (
     MIGRATIONS_DIR,
 )
 from clickhouse_migrations.migration import Migration
-from clickhouse_migrations.migrator import Migrator
+from clickhouse_migrations.migrator import MIGRATION_LOG_FORMATS, Migrator
 
 
 def log_level(value: str) -> str:
@@ -29,6 +29,15 @@ def log_level(value: str) -> str:
         return value.upper()
 
     raise ValueError
+
+
+def migration_log_format(value: str) -> str:
+    normalized_value = value.lower()
+    if normalized_value in MIGRATION_LOG_FORMATS:
+        return normalized_value
+    raise ValueError(
+        f"Unknown migration log format: {value}. Expected one of: {', '.join(MIGRATION_LOG_FORMATS)}"
+    )
 
 
 def cast_to_bool(value: str):
@@ -89,6 +98,12 @@ def get_context(args):
         default=os.environ.get("LOG_LEVEL", "WARNING"),
         type=log_level,
         help="Log level",
+    )
+    parser.add_argument(
+        "--migration-log-format",
+        default=os.environ.get("MIGRATION_LOG_FORMAT", "full"),
+        type=migration_log_format,
+        help="Migration log format: full or compact",
     )
     parser.add_argument(
         "--cluster-name",
@@ -157,6 +172,7 @@ def do_migrate(cluster, ctx) -> List[Migration]:
         multi_statement=ctx.multi_statement,
         dryrun=ctx.dry_run,
         fake=ctx.fake,
+        migration_log_format=ctx.migration_log_format,
     )
 
 

--- a/src/clickhouse_migrations/migrator.py
+++ b/src/clickhouse_migrations/migrator.py
@@ -6,11 +6,27 @@ from clickhouse_driver import Client
 from clickhouse_migrations.exceptions import MigrationException
 from clickhouse_migrations.migration import Migration
 
+MIGRATION_LOG_FORMAT_FULL = "full"
+MIGRATION_LOG_FORMAT_COMPACT = "compact"
+MIGRATION_LOG_FORMATS = (MIGRATION_LOG_FORMAT_FULL, MIGRATION_LOG_FORMAT_COMPACT)
+
 
 class Migrator:
-    def __init__(self, conn: Client, dryrun: bool = False):
+    def __init__(
+        self,
+        conn: Client,
+        dryrun: bool = False,
+        migration_log_format: str = MIGRATION_LOG_FORMAT_FULL,
+    ):
+        if migration_log_format not in MIGRATION_LOG_FORMATS:
+            raise ValueError(
+                f"Unknown migration log format: {migration_log_format}. "
+                f"Expected one of: {', '.join(MIGRATION_LOG_FORMATS)}"
+            )
+
         self._conn: Client = conn
         self._dryrun = dryrun
+        self._migration_log_format = migration_log_format
 
     def init_schema(self, cluster_name: Optional[str] = None):
         cluster_schema = f"""CREATE TABLE IF NOT EXISTS schema_versions ON CLUSTER "{cluster_name}" (
@@ -92,6 +108,12 @@ ORDER BY tuple(created_at)"""
         ]
         return sorted(to_apply, key=lambda x: x.version)
 
+    def format_migration_log(self, migration: Migration) -> str:
+        if self._migration_log_format == MIGRATION_LOG_FORMAT_COMPACT:
+            return f"version={migration.version}, md5={migration.md5}"
+
+        return str(migration)
+
     def apply_migration(
         self,
         migrations: List[Migration],
@@ -108,7 +130,7 @@ ORDER BY tuple(created_at)"""
             return []
 
         for migration in migrations_to_process:
-            logging.info("Execute migration %s", migration)
+            logging.info("Execute migration %s", self.format_migration_log(migration))
 
             statements = self.script_to_statements(migration.script, multi_statement)
 

--- a/src/tests/test_command_line.py
+++ b/src/tests/test_command_line.py
@@ -43,3 +43,18 @@ def test_check_create_db_if_not_exists_ok():
 
     context = get_context(["--no-create-db-if-not-exists"])
     assert context.create_db_if_not_exists is False
+
+
+def test_check_migration_log_format_arg_ok():
+    context = get_context([])
+    assert context.migration_log_format == "full"
+
+    context = get_context(["--migration-log-format", "compact"])
+    assert context.migration_log_format == "compact"
+
+
+def test_check_migration_log_format_env_ok(monkeypatch):
+    monkeypatch.setenv("MIGRATION_LOG_FORMAT", "compact")
+
+    context = get_context([])
+    assert context.migration_log_format == "compact"

--- a/src/tests/test_migrator.py
+++ b/src/tests/test_migrator.py
@@ -1,3 +1,6 @@
+import pytest
+
+from clickhouse_migrations.migration import Migration
 from clickhouse_migrations.migrator import Migrator
 
 
@@ -45,3 +48,30 @@ def test_split_and_ignore_empy_ok():
 
     assert len(statemets) == 1
     assert statemets[0][-1] == ";"
+
+
+def test_full_migration_log_format_keeps_previous_behavior():
+    migration = Migration(
+        version=1,
+        md5="abc",
+        script="CREATE TABLE test(value String)",
+    )
+    migrator = Migrator(None)
+
+    assert migrator.format_migration_log(migration) == str(migration)
+
+
+def test_compact_migration_log_format_does_not_include_script():
+    migration = Migration(
+        version=1,
+        md5="abc",
+        script="CREATE TABLE test(value String)",
+    )
+    migrator = Migrator(None, migration_log_format="compact")
+
+    assert migrator.format_migration_log(migration) == "version=1, md5=abc"
+
+
+def test_unknown_migration_log_format_raises_error():
+    with pytest.raises(ValueError):
+        Migrator(None, migration_log_format="unknown")


### PR DESCRIPTION
Currently, info logs print the full migration object
Since migration contains the full script, enabling logging can produce very large logs

This PR keeps the current behavior as the default and adds a compact mode

Ran full tox suite successfully

P.S. I know that this can be worked around in code by wrapping the migration call or adding custom logging around it
But I think that having this as a built-in option could be useful