### PR TITLE
Derive package version from git tag via setuptools-scm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from git tags/history
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -4,18 +4,21 @@ on:
     types: [published]
 
 jobs:
-  test:
+  publish:
     name: Publish distribution 📦 to PyPI
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the package version from the release tag
+          fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Setup
         run: make setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,14 @@ optional-dependencies.testing = [
 dynamic =["version", "readme"]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}
-version = {attr = "clickhouse_migrations.__version__"}
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.setuptools]
 package-dir = { "clickhouse_migrations" = "src/clickhouse_migrations", "tests" = "src/tests" }
@@ -54,9 +56,6 @@ universal = true
 
 [tool.isort]
 profile = "black"
-
-[tool.hatch.version]
-source = "vcs"
 
 [project.scripts]
 clickhouse-migrations = "clickhouse_migrations.command_line:main"

--- a/src/clickhouse_migrations/__init__.py
+++ b/src/clickhouse_migrations/__init__.py
@@ -1,6 +1,7 @@
 """
 Simple file-based migrations for clickhouse
 """
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:

--- a/src/clickhouse_migrations/__init__.py
+++ b/src/clickhouse_migrations/__init__.py
@@ -1,5 +1,9 @@
 """
 Simple file-based migrations for clickhouse
 """
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "0.11.0"
+try:
+    __version__ = version("clickhouse-migrations")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"


### PR DESCRIPTION
Releasing now only requires publishing a GitHub release — the package version is taken from the release tag instead of a hardcoded __version__ bump.

- pyproject.toml: add setuptools-scm, drop static version attr and leftover [tool.hatch.version] section
- __init__.py: expose __version__ from installed package metadata
- publish workflow: fetch tags for setuptools-scm, bump outdated actions (checkout v4, setup-python v5), Python 3.13