### PR TITLE
Add community health files and expand PyPI keywords

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for taking the time to contribute! This project is a small, actively
+maintained library for running ClickHouse migrations, and contributions of all
+sizes are welcome — bug reports, docs, and code.
+
+## Ways to contribute
+
+- **Report a bug** — open an issue with the Bug report template.
+- **Request a feature** — open an issue with the Feature request template.
+- **Send a pull request** — see the workflow below.
+
+For anything large, it's best to open an issue first so we can agree on the
+approach before you invest time.
+
+## Development setup
+
+Requirements: Python 3.9+, Docker (for the integration tests), and `make`.
+
+```bash
+# Install the tooling (tox)
+make setup
+
+# Install the package with test dependencies into your own venv
+python -m pip install -e ".[testing]"
+```
+
+## Running the tests
+
+The test suite is split into **unit** tests (no database needed) and
+**integration** tests (require a running ClickHouse cluster).
+
+```bash
+# Unit tests only — fast, no ClickHouse required
+pytest src -m "not integration"
+
+# Full suite (unit + integration): start ClickHouse first
+make docker-compose-up-deamon
+make test            # runs tox: linters + tests + coverage
+make docker-compose-down
+```
+
+Integration tests live under `src/tests/integration/` and are auto-marked with
+the `integration` marker.
+
+## Linting and formatting
+
+```bash
+make fix     # auto-format with isort + black
+make test    # also runs flake8 and pylint via tox
+```
+
+CI enforces `isort`, `black`, `flake8`, `pylint` (10.00/10), and coverage
+thresholds (99% for the package, 100% for tests), so please run the checks
+locally before pushing.
+
+## Migration file convention
+
+Migration files are named `{VERSION}_{name}.sql`, e.g. `001_init.sql`. The
+version is the integer prefix before the first `_` and must be unique within a
+migrations directory.
+
+## Pull request workflow
+
+1. Fork the repo and create a topic branch from `main`.
+2. Make your change, with tests. New behavior should be covered.
+3. Run `make fix` and make sure the checks pass.
+4. Add a note to `CHANGELOG.md` if the change is user-facing.
+5. Open the PR against `main` with a clear description of the change and why.
+
+Versioning and releases are handled by the maintainer via GitHub Releases.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with clickhouse-migrations
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug! Please fill in the details below.
+  - type: input
+    id: version
+    attributes:
+      label: clickhouse-migrations version
+      placeholder: e.g. 0.11.0
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: e.g. 3.12
+    validations:
+      required: true
+  - type: input
+    id: clickhouse-version
+    attributes:
+      label: ClickHouse version
+      placeholder: e.g. 24.3
+    validations:
+      required: false
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Single node
+        - Cluster
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: migration
+    attributes:
+      label: Migration file(s) / command
+      description: The migration SQL and/or the command or code you ran.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Usage help / documentation
+    url: https://github.com/zifter/clickhouse-migrations#usage
+    about: Check the README usage section and existing issues before opening a new one.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what is missing or hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What does this PR do?
+
+<!-- Brief description of the change and the motivation. -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] Tests added/updated for the change
+- [ ] `make fix` run and linters pass (isort, black, flake8, pylint)
+- [ ] Docs / README updated if user-facing
+- [ ] `CHANGELOG.md` updated if user-facing

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version on
+[PyPI](https://pypi.org/project/clickhouse-migrations/) receives fixes. Please
+upgrade to the latest version before reporting an issue.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, use GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/zifter/clickhouse-migrations/security/advisories/new).
+
+Include as much detail as you can:
+
+- affected version(s),
+- a description of the vulnerability and its impact,
+- steps to reproduce (a minimal example is ideal).
+
+You can expect an initial response within a few days. Once a fix is available it
+will be released to PyPI and the advisory will be published.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,14 @@ requires-python = ">=3.9, <4"
 keywords = [
     "clickhouse",
     "migrations",
+    "migration",
+    "database",
+    "database-migration",
+    "schema-migration",
+    "sql",
+    "ddl",
+    "olap",
+    "cli",
 ]
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
Adds standard community health files to raise the project's "maturity" signals and satisfy GitHub Community Standards.

- `CONTRIBUTING.md` — dev setup, unit vs integration test split (`pytest -m "not integration"` needs no ClickHouse), lint/format workflow, migration file convention, PR workflow.
- `SECURITY.md` — supported versions + private vulnerability reporting.
- Issue forms (bug report / feature request) + template config.
- Pull request template with a review checklist.
- Broaden PyPI `keywords` for discoverability.

Repo settings done separately: Homepage set to PyPI, GitHub Discussions enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)