### PR TITLE
Upload coverage to Codecov and add coverage badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,14 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Upload coverage to Codecov
+        if: matrix.py == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
       - name: Stop
         if: always()
         run: make docker-compose-down

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![ci](https://github.com/zifter/clickhouse-migrations/actions/workflows/ci.yaml/badge.svg)](https://github.com/zifter/clickhouse-migrations/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/zifter/clickhouse-migrations/branch/main/graph/badge.svg)](https://codecov.io/gh/zifter/clickhouse-migrations)
 [![release](https://img.shields.io/github/release/zifter/clickhouse-migrations.svg)](https://github.com/zifter/clickhouse-migrations/releases)
 [![PyPI version](https://badge.fury.io/py/clickhouse-migrations.svg)]([https://badge.fury.io/py/clickhouse-migrate](https://pypi.org/project/clickhouse-migrations/))
 [![supported versions](https://img.shields.io/pypi/pyversions/clickhouse-migrations.svg)](https://pypi.org/project/clickhouse-migrations/)


### PR DESCRIPTION
Wires up code coverage reporting to Codecov.

- Non-blocking Codecov upload step in CI (once, on the 3.13 job), using `CODECOV_TOKEN` from repo secrets with `fail_ci_if_error: false` so it can never break CI.
- Coverage badge in the README.

The `CODECOV_TOKEN` secret is already configured. The badge will populate after the first upload once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)