### PR TITLE
Fix outdated multi-statement caveat in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ Parameter | Description | Default
 ### Notes
 The ClickHouse driver does not natively support executing multiple statements in a single query.
 To allow for multiple statements in a single migration, you can use the `multi_statement` param.
-There are two important caveats:
-* This mode splits the migration text into separately-executed statements by a semi-colon `;`. Thus cannot be used when a statement in the migration contains a string with a semi-colon.
+This mode splits the migration text into separately-executed statements on the semicolon `;`. Semicolons inside string literals (`'...'`), quoted identifiers (`` `...` `` and `"..."`) and SQL comments (`-- ...` and `/* ... */`) are recognised and do not split a statement.
+
+One important caveat:
 * The queries are not executed in any sort of transaction/batch, meaning you are responsible for fixing partial migrations.
 
 ## Star History


### PR DESCRIPTION
The README's multi-statement note still said the mode "cannot be used when a statement contains a string with a semicolon". Since #50 the splitter recognises semicolons inside string literals, quoted identifiers (`` `...` ``, `"..."`) and SQL comments (`-- ...`, `/* ... */`) and does not split on them, so that caveat is no longer accurate.

Updated the note to describe the actual behavior; only the no-transaction caveat remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)