### PR TITLE
Add GitHub Action and Docker image for running migrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.idea
+.tox
+.pytest_cache
+htmlcov
+dist
+build
+*.egg-info
+coverage.xml
+.coverage
+dev
+__pycache__
+*.pyc
+GROWTH.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,58 @@
+name: docker
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'release' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event_name == 'release' && steps.meta.outputs.version || '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# ---- build stage: build a wheel from the source tree ----
+FROM python:3.13-slim AS build
+
+WORKDIR /src
+COPY . .
+
+# The version is normally derived from git tags by setuptools-scm. The build
+# context excludes .git (see .dockerignore), so CI passes the version here; a
+# plain `docker build` falls back to the fallback_version from pyproject.toml.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+
+RUN pip install --no-cache-dir build && python -m build --wheel --outdir /dist
+
+# ---- runtime stage: install just the wheel + runtime deps ----
+FROM python:3.13-slim
+
+LABEL org.opencontainers.image.source="https://github.com/zifter/clickhouse-migrations"
+LABEL org.opencontainers.image.description="Simple file-based schema migrations for ClickHouse"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=build /dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm -rf /tmp/*.whl
+
+# Mount your migrations here (e.g. `-v $PWD/migrations:/migrations`); the CLI
+# reads this path by default, override with `--migrations-dir` if needed.
+ENV MIGRATIONS_DIR=/migrations
+WORKDIR /migrations
+
+ENTRYPOINT ["clickhouse-migrations"]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,71 @@ Parameter | Description | Default
 `secure` | Use secure (TLS) connection | `False`
 `migration_log_format` | Migration log format `full` logs the full Migration object, `compact` logs only version and md5 | `full`
 
+### In CI (GitHub Action)
+
+Apply migrations from a GitHub workflow with the composite action:
+
+```yaml
+- uses: zifter/clickhouse-migrations@v1
+  with:
+    migrations-dir: ./migrations
+    db-host: localhost
+    db-port: "9000"
+    db-user: default
+    db-password: ${{ secrets.CLICKHOUSE_PASSWORD }}
+    db-name: mydb
+    # or connect via a single URL instead of the db-* inputs:
+    # db-url: ${{ secrets.CLICKHOUSE_URL }}
+    # any extra raw CLI flags:
+    # extra-args: --secure --create-db-if-not-exists
+```
+
+Inputs: `migrations-dir`, `db-url`, `db-host`, `db-port`, `db-user`, `db-password`, `db-name`, `cluster-name`, `extra-args`, `version` (pin the package version), `python-version`. You can also pin an exact release, e.g. `zifter/clickhouse-migrations@v0.12.0`.
+
+### With Docker
+
+An image is published to the GitHub Container Registry. Mount your migrations directory at `/migrations`:
+
+```bash
+docker run --rm \
+    -v "$PWD/migrations:/migrations" \
+    ghcr.io/zifter/clickhouse-migrations:latest \
+    --db-url clickhouse://default:secret@clickhouse:9000/mydb
+```
+
+Run migrations as a Kubernetes `Job`, e.g. before rolling out a deployment:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: clickhouse-migrations
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrations
+          image: ghcr.io/zifter/clickhouse-migrations:latest
+          args: ["--create-db-if-not-exists"]
+          env:
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse
+                  key: url
+          volumeMounts:
+            - name: migrations
+              mountPath: /migrations
+      volumes:
+        - name: migrations
+          configMap:
+            name: clickhouse-migrations
+```
+
+Migrations are provided here via a ConfigMap; alternatively bake them into your own image with `FROM ghcr.io/zifter/clickhouse-migrations`.
+
 ### Notes
 The ClickHouse driver does not natively support executing multiple statements in a single query.
 To allow for multiple statements in a single migration, you can use the `multi_statement` param.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,95 @@
+name: "ClickHouse Migrations"
+description: "Apply file-based schema migrations to ClickHouse from a directory of .sql files."
+branding:
+  icon: "database"
+  color: "yellow"
+
+inputs:
+  migrations-dir:
+    description: "Path to the directory with migration files"
+    required: false
+    default: "./migrations"
+  db-url:
+    description: "ClickHouse connection URL (clickhouse://user:password@host:port/db). Takes precedence over the individual db-* inputs."
+    required: false
+    default: ""
+  db-host:
+    description: "ClickHouse host"
+    required: false
+    default: "localhost"
+  db-port:
+    description: "ClickHouse native port"
+    required: false
+    default: "9000"
+  db-user:
+    description: "ClickHouse user"
+    required: false
+    default: "default"
+  db-password:
+    description: "ClickHouse password"
+    required: false
+    default: ""
+  db-name:
+    description: "ClickHouse database name"
+    required: false
+    default: ""
+  cluster-name:
+    description: "ClickHouse cluster name (for ON CLUSTER / replicated deployments)"
+    required: false
+    default: ""
+  extra-args:
+    description: "Additional raw CLI arguments, e.g. '--dry-run --secure --create-db-if-not-exists'"
+    required: false
+    default: ""
+  version:
+    description: "Version of clickhouse-migrations to install from PyPI (defaults to the latest)"
+    required: false
+    default: ""
+  python-version:
+    description: "Python version used to run the tool"
+    required: false
+    default: "3.13"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install clickhouse-migrations
+      shell: bash
+      env:
+        CHM_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [ -n "$CHM_VERSION" ]; then
+          pip install "clickhouse-migrations==$CHM_VERSION"
+        else
+          pip install clickhouse-migrations
+        fi
+
+    - name: Apply migrations
+      shell: bash
+      env:
+        CHM_MIGRATIONS_DIR: ${{ inputs.migrations-dir }}
+        CHM_DB_URL: ${{ inputs.db-url }}
+        CHM_DB_HOST: ${{ inputs.db-host }}
+        CHM_DB_PORT: ${{ inputs.db-port }}
+        CHM_DB_USER: ${{ inputs.db-user }}
+        CHM_DB_PASSWORD: ${{ inputs.db-password }}
+        CHM_DB_NAME: ${{ inputs.db-name }}
+        CHM_CLUSTER_NAME: ${{ inputs.cluster-name }}
+        CHM_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        set -euo pipefail
+        args=(--migrations-dir "$CHM_MIGRATIONS_DIR")
+        if [ -n "$CHM_DB_URL" ]; then
+          args+=(--db-url "$CHM_DB_URL")
+        else
+          args+=(--db-host "$CHM_DB_HOST" --db-port "$CHM_DB_PORT" --db-user "$CHM_DB_USER" --db-password "$CHM_DB_PASSWORD")
+        fi
+        if [ -n "$CHM_DB_NAME" ]; then args+=(--db-name "$CHM_DB_NAME"); fi
+        if [ -n "$CHM_CLUSTER_NAME" ]; then args+=(--cluster-name "$CHM_CLUSTER_NAME"); fi
+        clickhouse-migrations "${args[@]}" $CHM_EXTRA_ARGS


### PR DESCRIPTION
Makes the tool easy to adopt in CI/CD and containerized deploys — the two most common ways migrations get run in practice.

## What's added

- **Composite GitHub Action** (`action.yml`): apply migrations from a workflow with
  ```yaml
  - uses: zifter/clickhouse-migrations@v1
    with:
      migrations-dir: ./migrations
      db-url: ${{ secrets.CLICKHOUSE_URL }}
  ```
  Inputs: `migrations-dir`, `db-url` or individual `db-host/port/user/password/name`, `cluster-name`, `extra-args`, `version` (pin the package), `python-version`.
- **Docker image** (`Dockerfile` + `.dockerignore`): small multi-stage image, entrypoint is the CLI, migrations mounted at `/migrations`. The version is injected from the release tag via setuptools-scm at build time.
- **GHCR publish workflow** (`.github/workflows/docker-publish.yml`): builds a multi-arch (amd64/arm64) image and pushes to `ghcr.io/zifter/clickhouse-migrations` on release; build-only validation on PRs.
- **README**: GitHub Action usage, `docker run`, and a Kubernetes `Job` example.

## Verification (local, against a live ClickHouse)

- Image builds; `--version` resolves; an end-to-end `docker run` migration creates the database, initializes `schema_versions`, applies a migration, and records the version.
- The composite action's shell step (run in bash) applies migrations end-to-end, including `extra-args` word-splitting.

## Follow-ups (need maintainer action, not in this PR)

- Push a `v1` tag (or major-version tag) so `@v1` resolves; users can also pin `@vX.Y.Z`.
- After the first release build, the GHCR package may need to be set to **public** in the package settings.
- Optionally publish the Action to the GitHub Marketplace from the release UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)