### PR TITLE
Introduce a driver-agnostic Connection adapter (no behavior change)

### DIFF
--- a/src/clickhouse_migrations/clickhouse_cluster.py
+++ b/src/clickhouse_migrations/clickhouse_cluster.py
@@ -4,10 +4,11 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from clickhouse_driver import Client
 
+from clickhouse_migrations.connection import ClickhouseDriverConnection, Connection
 from clickhouse_migrations.defaults import DB_HOST, DB_PASSWORD, DB_PORT, DB_USER
 from clickhouse_migrations.migration import Migration, MigrationStorage
 from clickhouse_migrations.migrator import STATUS_PENDING, Migrator, StatusRow
-from clickhouse_migrations.util import quote_identifier
+from clickhouse_migrations.util import quote_identifier, quote_string
 
 
 class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
@@ -49,7 +50,7 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
             self.db_user = db_user
             self.db_password = db_password
 
-    def connection(self, db_name: Optional[str] = None) -> Client:
+    def connection(self, db_name: Optional[str] = None) -> Connection:
         db_name = db_name if db_name is not None else self.default_db_name
 
         if self._parsed_url is not None:
@@ -67,7 +68,7 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
                 secure=self.secure,
                 **self.connection_kwargs,
             )
-        return ch_client
+        return ClickhouseDriverConnection(ch_client)
 
     def create_db(
         self, db_name: Optional[str] = None, cluster_name: Optional[str] = None
@@ -76,11 +77,11 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
 
         with self.connection("") as conn:
             if cluster_name is None:
-                conn.execute(
+                conn.command(
                     f"CREATE DATABASE IF NOT EXISTS {quote_identifier(db_name)}"
                 )
             else:
-                conn.execute(
+                conn.command(
                     f"CREATE DATABASE IF NOT EXISTS {quote_identifier(db_name)} "
                     f"ON CLUSTER {quote_identifier(cluster_name)}"
                 )
@@ -98,8 +99,7 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
         db_name = db_name if db_name is not None else self.default_db_name
 
         with self.connection(db_name) as conn:
-            result = conn.execute("show tables")
-            return [t[0] for t in result]
+            return [row["name"] for row in conn.query("SHOW TABLES")]
 
     def migrate(
         self,
@@ -143,11 +143,10 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
         # Read-only: never create the database or the schema table. If the
         # schema table is missing, nothing has been applied yet.
         with self.connection("") as conn:
-            initialized = conn.execute(
-                "SELECT count() FROM system.tables "
-                "WHERE database = %(db)s AND name = 'schema_versions'",
-                {"db": db_name},
-            )[0][0]
+            initialized = conn.query(
+                "SELECT count() AS n FROM system.tables "
+                f"WHERE database = {quote_string(db_name)} AND name = 'schema_versions'"
+            )[0]["n"]
 
         if not initialized:
             return [StatusRow(m.version, STATUS_PENDING, m.md5, None) for m in incoming]

--- a/src/clickhouse_migrations/connection.py
+++ b/src/clickhouse_migrations/connection.py
@@ -1,0 +1,68 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+
+class Connection(ABC):
+    """Driver-agnostic connection used by the migrator.
+
+    Concrete implementations wrap a specific ClickHouse driver so the rest of
+    the code base does not depend on any single driver's API.
+    """
+
+    @abstractmethod
+    def command(self, statement: str) -> None:
+        """Execute a statement that does not return rows (DDL/DML)."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def query(self, statement: str) -> List[Dict]:
+        """Execute a query and return its rows as dicts keyed by column name."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def insert(self, table: str, rows: List[Dict]) -> None:
+        """Insert a list of row dicts into a table."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def __enter__(self) -> "Connection":
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class ClickhouseDriverConnection(Connection):
+    """Connection backed by clickhouse-driver (native TCP protocol)."""
+
+    def __init__(self, client):
+        self._client = client
+
+    def command(self, statement: str) -> None:
+        logging.debug(statement)
+        self._client.execute(statement)
+
+    def query(self, statement: str) -> List[Dict]:
+        logging.debug(statement)
+        data, columns = self._client.execute(statement, with_column_types=True)
+        names = [c[0] for c in columns]
+        return [dict(zip(names, row)) for row in data]
+
+    def insert(self, table: str, rows: List[Dict]) -> None:
+        columns = list(rows[0].keys())
+        column_list = ", ".join(columns)
+        self._client.execute(f"INSERT INTO {table} ({column_list}) VALUES", rows)
+
+    # Passthrough kept so existing tests and callers can use the native client
+    # API directly against a clickhouse-driver connection.
+    def execute(self, *args, **kwargs):
+        return self._client.execute(*args, **kwargs)
+
+    def __enter__(self) -> "ClickhouseDriverConnection":
+        self._client.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._client.__exit__(exc_type, exc_value, traceback)

--- a/src/clickhouse_migrations/migrator.py
+++ b/src/clickhouse_migrations/migrator.py
@@ -3,8 +3,7 @@ import re
 from collections import namedtuple
 from typing import Dict, List, Optional, Tuple
 
-from clickhouse_driver import Client
-
+from clickhouse_migrations.connection import Connection
 from clickhouse_migrations.exceptions import MigrationException
 from clickhouse_migrations.migration import Migration
 from clickhouse_migrations.util import quote_identifier
@@ -41,7 +40,7 @@ _STATEMENT_TOKEN_RE = re.compile(
 class Migrator:
     def __init__(
         self,
-        conn: Client,
+        conn: Connection,
         dryrun: bool = False,
         migration_log_format: str = MIGRATION_LOG_FORMAT_FULL,
     ):
@@ -51,7 +50,7 @@ class Migrator:
                 f"Expected one of: {', '.join(MIGRATION_LOG_FORMATS)}"
             )
 
-        self._conn: Client = conn
+        self._conn: Connection = conn
         self._dryrun = dryrun
         self._migration_log_format = migration_log_format
 
@@ -72,7 +71,7 @@ class Migrator:
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{{database}}/{{table}}', '{{replica}}')
 ORDER BY tuple(created_at)"""
 
-        self._execute(schema)
+        self._conn.command(schema)
 
     def query_applied_migrations(self) -> List[Migration]:
         self.optimize_schema_table()
@@ -84,12 +83,7 @@ ORDER BY tuple(created_at)"""
         FROM schema_versions
         ORDER BY version"""
 
-        result = self._execute(query, with_column_types=True)
-        column_names = [c[0] for c in result[len(result) - 1]]
-
-        migrations_as_dict = [dict(zip(column_names, d)) for d in result[0]]
-
-        return [Migration(**d) for d in migrations_as_dict]
+        return [Migration(**row) for row in self._conn.query(query)]
 
     def migrations_to_apply(self, incoming: List[Migration]) -> List[Migration]:
         applied = self.query_applied_migrations()
@@ -140,11 +134,12 @@ ORDER BY tuple(created_at)"""
         return self._build_status(incoming, self._query_applied_meta())
 
     def _query_applied_meta(self) -> Dict[int, Tuple[str, object]]:
-        result = self._execute(
-            "SELECT version, argMax(md5, created_at), max(created_at) "
+        rows = self._conn.query(
+            "SELECT version, argMax(md5, created_at) AS md5, "
+            "max(created_at) AS applied_at "
             "FROM schema_versions GROUP BY version ORDER BY version"
         )
-        return {row[0]: (row[1], row[2]) for row in result}
+        return {row["version"]: (row["md5"], row["applied_at"]) for row in rows}
 
     @staticmethod
     def _build_status(
@@ -206,54 +201,42 @@ ORDER BY tuple(created_at)"""
                 elif self._dryrun:
                     logging.info("Dry run mode, would have executed: %s", statement)
                 else:
-                    self._execute(statement)
+                    self._conn.command(statement)
 
             logging.info("Migration applied, need to update schema version table.")
             if fake:
                 logging.debug("update schema versions because fake option is enabled")
-                self._execute(
-                    "ALTER TABLE schema_versions DELETE WHERE version = %(version)s;",
-                    {
-                        "version": migration.version,
-                    },
+                self._conn.command(
+                    "ALTER TABLE schema_versions "
+                    f"DELETE WHERE version = {int(migration.version)}"
                 )
-                self._execute(
-                    "INSERT INTO schema_versions(version, script, md5) VALUES",
-                    [
-                        {
-                            "version": migration.version,
-                            "script": migration.script,
-                            "md5": migration.md5,
-                        }
-                    ],
-                )
+                self._insert_schema_version(migration)
             elif self._dryrun:
                 logging.debug(
                     "Skip updating schema versions because dry run is enabled"
                 )
             else:
                 logging.debug("Insert new schemas")
-                self._execute(
-                    "INSERT INTO schema_versions(version, script, md5) VALUES",
-                    [
-                        {
-                            "version": migration.version,
-                            "script": migration.script,
-                            "md5": migration.md5,
-                        }
-                    ],
-                )
+                self._insert_schema_version(migration)
 
             logging.info("Migration is fully applied.")
 
         return migrations_to_process
 
-    def optimize_schema_table(self):
-        self._execute("OPTIMIZE TABLE schema_versions FINAL;")
+    def _insert_schema_version(self, migration: Migration) -> None:
+        self._conn.insert(
+            "schema_versions",
+            [
+                {
+                    "version": migration.version,
+                    "script": migration.script,
+                    "md5": migration.md5,
+                }
+            ],
+        )
 
-    def _execute(self, statement, *args, **kwargs):
-        logging.debug(statement)
-        return self._conn.execute(statement, *args, **kwargs)
+    def optimize_schema_table(self):
+        self._conn.command("OPTIMIZE TABLE schema_versions FINAL")
 
     @classmethod
     def script_to_statements(cls, script: str, multi_statement: bool) -> List[str]:

--- a/src/clickhouse_migrations/util.py
+++ b/src/clickhouse_migrations/util.py
@@ -5,3 +5,12 @@ def quote_identifier(identifier: str) -> str:
     escaped by doubling it, so a name can never break out of the quoting.
     """
     return '"' + identifier.replace('"', '""') + '"'
+
+
+def quote_string(value: str) -> str:
+    """Quote a string literal for use in ClickHouse SQL.
+
+    Backslashes and single quotes are escaped so the value cannot break out
+    of the surrounding quotes.
+    """
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"

--- a/src/tests/test_clickhouse_cluster.py
+++ b/src/tests/test_clickhouse_cluster.py
@@ -2,6 +2,12 @@ from clickhouse_migrations.clickhouse_cluster import ClickhouseCluster
 from clickhouse_migrations.util import quote_identifier
 
 
+def _native(cluster, db_name):
+    # Reach the underlying clickhouse-driver Connection for white-box assertions.
+    conn = cluster.connection(db_name)
+    return conn._client.connection  # pylint: disable=protected-access
+
+
 def test_db_url_extracts_database_name():
     cluster = ClickhouseCluster(db_url="clickhouse://default:@localhost:9000/mydb")
     assert cluster.default_db_name == "mydb"
@@ -14,20 +20,20 @@ def test_db_url_without_database_keeps_none():
 
 def test_db_url_connection_uses_database_as_path():
     cluster = ClickhouseCluster(db_url="clickhouse://default:@localhost:9000/mydb")
-    client = cluster.connection("otherdb")
+    conn = _native(cluster, "otherdb")
 
-    assert client.connection.database == "otherdb"
-    assert client.connection.secure_socket is False
+    assert conn.database == "otherdb"
+    assert conn.secure_socket is False
 
 
 def test_db_url_secure_flag_is_honored():
     cluster = ClickhouseCluster(
         db_url="clickhouse://default:@localhost:9000/mydb", secure=True
     )
-    client = cluster.connection("mydb")
+    conn = _native(cluster, "mydb")
 
-    assert client.connection.secure_socket is True
-    assert client.connection.database == "mydb"
+    assert conn.secure_socket is True
+    assert conn.database == "mydb"
 
 
 def test_db_url_secure_survives_existing_query_params():
@@ -35,26 +41,26 @@ def test_db_url_secure_survives_existing_query_params():
         db_url="clickhouse://default:@localhost:9000/mydb?connect_timeout=5",
         secure=True,
     )
-    client = cluster.connection("mydb")
+    conn = _native(cluster, "mydb")
 
-    assert client.connection.secure_socket is True
-    assert client.connection.database == "mydb"
+    assert conn.secure_socket is True
+    assert conn.database == "mydb"
 
 
 def test_host_based_secure_flag_is_honored():
     cluster = ClickhouseCluster(
         db_host="localhost", db_user="default", db_password="", secure=True
     )
-    client = cluster.connection("mydb")
+    conn = _native(cluster, "mydb")
 
-    assert client.connection.secure_socket is True
+    assert conn.secure_socket is True
 
 
 def test_host_based_defaults_to_insecure():
     cluster = ClickhouseCluster(db_host="localhost", db_user="default", db_password="")
-    client = cluster.connection("mydb")
+    conn = _native(cluster, "mydb")
 
-    assert client.connection.secure_socket is False
+    assert conn.secure_socket is False
 
 
 def test_quote_identifier_wraps_in_double_quotes():


### PR DESCRIPTION
Groundwork for #56 (clickhouse-connect support), split out so it can be reviewed as a pure, behavior-neutral refactor.

## What

The package talked to ClickHouse by calling `clickhouse-driver`'s `Client.execute(...)` directly all over `Migrator`/`ClickhouseCluster`. This introduces a small `Connection` abstraction — `command()`, `query() -> list[dict]`, `insert()` — so a second driver can be dropped in later without touching the migration logic.

- `connection.py`: `Connection` ABC + `ClickhouseDriverConnection`. The driver adapter **keeps a passthrough `execute()`**, so conftest and all integration tests (which use the native client API for setup/asserts) stay untouched.
- `Migrator` and `ClickhouseCluster` now use `command`/`query`/`insert`.
- Two small param-free rewrites so the same SQL works across drivers later: the status existence check uses `quote_string` instead of `%(db)s`, the fake-mode delete inlines `int(version)`, and the applied-meta query aliases `argMax(...) AS md5, max(...) AS applied_at`.

## Not in this PR

The `clickhouse-connect` adapter, the `--driver` flag, and the optional extra come in the follow-up (#56). This PR keeps **clickhouse-driver as the only driver, behavior identical**.

## Testing

Full suite green (112 tests, unchanged set), coverage **100%** package / 100% tests, isort/black/flake8/pylint 10.00/10.

Part of #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)