### PR TITLE
Support the official clickhouse-connect driver (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Package | Differences
 
 You can install from pypi using `pip install clickhouse-migrations`.
 
+By default it uses the native [`clickhouse-driver`](https://github.com/mymarilyn/clickhouse-driver) (TCP, port 9000). To use the official HTTP [`clickhouse-connect`](https://github.com/ClickHouse/clickhouse-connect) driver instead, install the extra and pass `--driver clickhouse-connect`:
+
+```bash
+pip install 'clickhouse-migrations[connect]'
+```
+
+With `clickhouse-connect` the default port is `8123` (HTTP). Connecting via `--db-url` is only supported with the default `clickhouse-driver`; use `--db-host`/`--db-port` for `clickhouse-connect`.
+
 ## Migration files
 
 Migration files follow the naming convention `{VERSION}_{name}.sql`, e.g. `001_init.sql`, `002_add_users.sql`.
@@ -88,6 +96,7 @@ CLI flag | Environment variable | Default
 `--secure` | `SECURE` | `false`
 `--log-level` | `LOG_LEVEL` | `WARNING`
 `--migration-log-format` | `MIGRATION_LOG_FORMAT` | `full`
+`--driver` | `DRIVER` | `clickhouse-driver`
 
 ### Migration status
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,13 @@ classifiers = [
 dependencies = [
     "clickhouse-driver>=0.2.2",
 ]
+optional-dependencies.connect = [
+    "clickhouse-connect>=0.7",
+]
 optional-dependencies.testing = [
     "pytest==8.4.1",
     "pytest-cov==6.2.1",
+    "clickhouse-connect>=0.7",
 ]
 dynamic =["version", "readme"]
 

--- a/src/clickhouse_migrations/clickhouse_cluster.py
+++ b/src/clickhouse_migrations/clickhouse_cluster.py
@@ -4,8 +4,17 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from clickhouse_driver import Client
 
-from clickhouse_migrations.connection import ClickhouseDriverConnection, Connection
-from clickhouse_migrations.defaults import DB_HOST, DB_PASSWORD, DB_PORT, DB_USER
+from clickhouse_migrations.connection import (
+    CLICKHOUSE_CONNECT,
+    CLICKHOUSE_DRIVER,
+    DEFAULT_PORT,
+    ClickhouseConnectConnection,
+    ClickhouseDriverConnection,
+    Connection,
+    import_clickhouse_connect,
+)
+from clickhouse_migrations.defaults import DB_HOST, DB_PASSWORD, DB_USER
+from clickhouse_migrations.exceptions import MigrationException
 from clickhouse_migrations.migration import Migration, MigrationStorage
 from clickhouse_migrations.migrator import STATUS_PENDING, Migrator, StatusRow
 from clickhouse_migrations.util import quote_identifier, quote_string
@@ -17,19 +26,26 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
         db_host: str = DB_HOST,
         db_user: str = DB_USER,
         db_password: str = DB_PASSWORD,
-        db_port: str = DB_PORT,
+        db_port: Optional[str] = None,
         db_url: Optional[str] = None,
         db_name: Optional[str] = None,
         secure: bool = False,
+        driver: str = CLICKHOUSE_DRIVER,
         **kwargs,
     ):
         self.db_url: Optional[str] = None
         self.default_db_name: Optional[str] = db_name
         self.secure: bool = secure
+        self.driver: str = driver
         self.connection_kwargs = kwargs
         self._parsed_url = None
 
         if db_url:
+            if driver != CLICKHOUSE_DRIVER:
+                raise MigrationException(
+                    "db_url is only supported with the clickhouse-driver driver; "
+                    "use db_host/db_port with clickhouse-connect"
+                )
             parsed = urlparse(db_url)
             path_db = parsed.path.lstrip("/")
             if path_db:
@@ -50,8 +66,25 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
             self.db_user = db_user
             self.db_password = db_password
 
+    def _resolved_port(self):
+        if self.db_port is not None:
+            return self.db_port
+        return DEFAULT_PORT[self.driver]
+
     def connection(self, db_name: Optional[str] = None) -> Connection:
         db_name = db_name if db_name is not None else self.default_db_name
+
+        if self.driver == CLICKHOUSE_CONNECT:
+            clickhouse_connect = import_clickhouse_connect()
+            client = clickhouse_connect.get_client(
+                host=self.db_host,
+                port=int(self._resolved_port()),
+                username=self.db_user,
+                password=self.db_password,
+                database=db_name or None,
+                secure=self.secure,
+            )
+            return ClickhouseConnectConnection(client)
 
         if self._parsed_url is not None:
             parsed = self._parsed_url
@@ -61,7 +94,7 @@ class ClickhouseCluster:  # pylint: disable=too-many-instance-attributes
         else:
             ch_client = Client(
                 self.db_host,
-                port=self.db_port,
+                port=self._resolved_port(),
                 user=self.db_user,
                 password=self.db_password,
                 database=db_name,

--- a/src/clickhouse_migrations/command_line.py
+++ b/src/clickhouse_migrations/command_line.py
@@ -8,10 +8,10 @@ from typing import List
 
 from clickhouse_migrations import __version__
 from clickhouse_migrations.clickhouse_cluster import ClickhouseCluster
+from clickhouse_migrations.connection import CLICKHOUSE_DRIVER, DRIVERS
 from clickhouse_migrations.defaults import (
     DB_HOST,
     DB_PASSWORD,
-    DB_PORT,
     DB_USER,
     MIGRATIONS_DIR,
 )
@@ -62,8 +62,15 @@ def _add_common_arguments(parser):
     )
     parser.add_argument(
         "--db-port",
-        default=os.environ.get("DB_PORT", DB_PORT),
-        help="Clickhouse database port",
+        default=os.environ.get("DB_PORT", None),
+        help="Clickhouse database port "
+        "(default: 9000 for clickhouse-driver, 8123 for clickhouse-connect)",
+    )
+    parser.add_argument(
+        "--driver",
+        default=os.environ.get("DRIVER", CLICKHOUSE_DRIVER),
+        choices=DRIVERS,
+        help="ClickHouse driver to use",
     )
     parser.add_argument(
         "--db-user",
@@ -189,6 +196,7 @@ def create_cluster(ctx) -> ClickhouseCluster:
         db_password=ctx.db_password,
         db_url=ctx.db_url,
         secure=ctx.secure,
+        driver=ctx.driver,
     )
 
 

--- a/src/clickhouse_migrations/connection.py
+++ b/src/clickhouse_migrations/connection.py
@@ -2,6 +2,28 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
+from clickhouse_migrations.exceptions import MigrationException
+
+CLICKHOUSE_DRIVER = "clickhouse-driver"
+CLICKHOUSE_CONNECT = "clickhouse-connect"
+DRIVERS = (CLICKHOUSE_DRIVER, CLICKHOUSE_CONNECT)
+
+# Default native (clickhouse-driver) / HTTP (clickhouse-connect) ports, used
+# when the caller does not set a port explicitly.
+DEFAULT_PORT = {CLICKHOUSE_DRIVER: 9000, CLICKHOUSE_CONNECT: 8123}
+
+
+def import_clickhouse_connect():
+    try:
+        import clickhouse_connect  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:
+        raise MigrationException(
+            "The clickhouse-connect driver is not installed. "
+            "Install it with: pip install 'clickhouse-migrations[connect]'"
+        ) from exc
+
+    return clickhouse_connect
+
 
 class Connection(ABC):
     """Driver-agnostic connection used by the migrator.
@@ -66,3 +88,30 @@ class ClickhouseDriverConnection(Connection):
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         self._client.__exit__(exc_type, exc_value, traceback)
+
+
+class ClickhouseConnectConnection(Connection):
+    """Connection backed by clickhouse-connect (official HTTP driver)."""
+
+    def __init__(self, client):
+        self._client = client
+
+    def command(self, statement: str) -> None:
+        logging.debug(statement)
+        self._client.command(statement)
+
+    def query(self, statement: str) -> List[Dict]:
+        logging.debug(statement)
+        result = self._client.query(statement)
+        return [dict(zip(result.column_names, row)) for row in result.result_rows]
+
+    def insert(self, table: str, rows: List[Dict]) -> None:
+        columns = list(rows[0].keys())
+        data = [[row[column] for column in columns] for row in rows]
+        self._client.insert(table, data=data, column_names=columns)
+
+    def __enter__(self) -> "ClickhouseConnectConnection":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._client.close()

--- a/src/tests/integration/test_cluster_support.py
+++ b/src/tests/integration/test_cluster_support.py
@@ -45,13 +45,13 @@ def test_migration_with_replicated_schema(_schema):
     with cluster.connection("pytest") as conn:
         for server in CLICKHOUSE_SERVERS:
             assert (
-                conn.execute(
+                conn.execute(  # pylint: disable=no-member
                     f"select count(*) from remote('{server}', 'pytest.schema_versions')"
                 )[0][0]
                 == 1
             )
             result_set.append(
-                conn.execute(
+                conn.execute(  # pylint: disable=no-member
                     f"select * from remote('{server}', 'pytest.schema_versions')"
                 )[0]
             )

--- a/src/tests/integration/test_connect_driver.py
+++ b/src/tests/integration/test_connect_driver.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from time import sleep
+
+import pytest
+
+from clickhouse_migrations.clickhouse_cluster import ClickhouseCluster
+from clickhouse_migrations.migrator import STATUS_APPLIED, STATUS_PENDING
+
+TESTS_DIR = Path(__file__).parents[1]
+MIGRATIONS = TESTS_DIR / "migrations"
+
+
+@pytest.fixture
+def connect_cluster() -> ClickhouseCluster:
+    return ClickhouseCluster(
+        db_host="localhost",
+        db_user="default",
+        db_password="",
+        db_name="pytest",
+        driver="clickhouse-connect",
+    )
+
+
+def test_connect_status_pending_before_migrate(connect_cluster: ClickhouseCluster):
+    rows = connect_cluster.status("pytest", MIGRATIONS)
+
+    assert len(rows) == 1
+    assert all(r.state == STATUS_PENDING for r in rows)
+
+
+def test_connect_migrate_and_status(connect_cluster: ClickhouseCluster):
+    applied = connect_cluster.migrate("pytest", MIGRATIONS)
+    assert len(applied) == 1
+
+    rows = connect_cluster.status("pytest", MIGRATIONS)
+    assert len(rows) == 1
+    assert all(r.state == STATUS_APPLIED for r in rows)
+    assert all(r.applied_at is not None for r in rows)
+
+
+def test_connect_fake(connect_cluster: ClickhouseCluster):
+    applied = connect_cluster.migrate("pytest", MIGRATIONS, fake=True)
+
+    assert len(applied) == 1
+    rows = connect_cluster.status("pytest", MIGRATIONS)
+    assert all(r.state == STATUS_APPLIED for r in rows)
+
+
+def test_connect_migrate_on_cluster(connect_cluster: ClickhouseCluster, _schema):
+    # Exercises ON CLUSTER / ReplicatedMergeTree DDL over the HTTP driver.
+    connect_cluster.migrate("pytest", MIGRATIONS, cluster_name="company_cluster")
+
+    # Replicated inserts propagate asynchronously; give them a moment.
+    sleep(1)
+
+    rows = connect_cluster.status("pytest", MIGRATIONS)
+    assert all(r.state == STATUS_APPLIED for r in rows)

--- a/src/tests/test_clickhouse_cluster.py
+++ b/src/tests/test_clickhouse_cluster.py
@@ -1,4 +1,7 @@
+import pytest
+
 from clickhouse_migrations.clickhouse_cluster import ClickhouseCluster
+from clickhouse_migrations.exceptions import MigrationException
 from clickhouse_migrations.util import quote_identifier
 
 
@@ -61,6 +64,30 @@ def test_host_based_defaults_to_insecure():
     conn = _native(cluster, "mydb")
 
     assert conn.secure_socket is False
+
+
+def test_port_defaults_per_driver():
+    # pylint: disable=protected-access
+    driver_cluster = ClickhouseCluster(db_host="h")
+    assert driver_cluster._resolved_port() == 9000
+
+    connect_cluster = ClickhouseCluster(db_host="h", driver="clickhouse-connect")
+    assert connect_cluster._resolved_port() == 8123
+
+
+def test_explicit_port_overrides_default():
+    cluster = ClickhouseCluster(
+        db_host="h", db_port="9999", driver="clickhouse-connect"
+    )
+    assert cluster._resolved_port() == "9999"  # pylint: disable=protected-access
+
+
+def test_db_url_with_connect_driver_raises():
+    with pytest.raises(MigrationException, match="db_url is only supported"):
+        ClickhouseCluster(
+            db_url="clickhouse://default:@localhost:9000/db",
+            driver="clickhouse-connect",
+        )
 
 
 def test_quote_identifier_wraps_in_double_quotes():

--- a/src/tests/test_command_line.py
+++ b/src/tests/test_command_line.py
@@ -179,6 +179,13 @@ def test_status_subcommand():
     assert context.db_name == "x"
 
 
+def test_driver_default_and_override():
+    assert get_context([]).driver == "clickhouse-driver"
+    assert (
+        get_context(["--driver", "clickhouse-connect"]).driver == "clickhouse-connect"
+    )
+
+
 def test_format_status_empty():
     assert format_status([]) == "No migrations found."
 

--- a/src/tests/test_connection.py
+++ b/src/tests/test_connection.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+
+from clickhouse_migrations.connection import import_clickhouse_connect
+from clickhouse_migrations.exceptions import MigrationException
+
+
+def test_import_clickhouse_connect_missing_raises_clear_error(monkeypatch):
+    # A None entry in sys.modules makes `import clickhouse_connect` fail.
+    monkeypatch.setitem(sys.modules, "clickhouse_connect", None)
+
+    with pytest.raises(MigrationException, match="clickhouse-connect"):
+        import_clickhouse_connect()


### PR DESCRIPTION
Closes #56. **Stacked on #59** (the Connection adapter) — review/merge that first; this PR's base is `add-connection-adapter`, so its diff is only the connect-specific changes.

## What

Adds `clickhouse-connect` (the official HTTP driver) as an alternative to the native `clickhouse-driver`, selectable per run:

```bash
pip install 'clickhouse-migrations[connect]'
clickhouse-migrations --driver clickhouse-connect --db-host ch --db-name mydb ...
```

- `connection.py`: `ClickhouseConnectConnection` adapter (`command`/`query`/`insert`) + a lazy importer that raises a clear, actionable error when the extra isn't installed.
- `ClickhouseCluster`: `driver` selection; port defaults to **9000** (clickhouse-driver) or **8123** (clickhouse-connect) when unset; `db_url` is rejected for clickhouse-connect (use `--db-host`/`--db-port`).
- CLI: `--driver` (env `DRIVER`), default `clickhouse-driver` — **no change for existing users**. `--db-port` now resolves per driver.
- `clickhouse-connect` is both an optional user extra (`[connect]`) and a **test** dependency, so CI exercises the connect adapter.

## Testing

- unit: driver flag parsing, per-driver port defaults, `db_url`+connect guard, missing-extra error.
- integration (connect, against the dev HTTP port 8123): migrate, status, fake, and **`ON CLUSTER` / ReplicatedMergeTree DDL over HTTP** (de-risks replicated DDL on the HTTP driver).
- Full suite green (121 tests), coverage **100%** package / 100% tests, isort/black/flake8/pylint 10.00/10.

## Notes / bounded scope
- `db_url` parity for connect (http/https/dsn) is intentionally out of scope for v1 — host/port is required for clickhouse-connect, and this is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)