### PR TITLE
Bundle both drivers in the Docker image and GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ LABEL org.opencontainers.image.description="Simple file-based schema migrations 
 LABEL org.opencontainers.image.licenses="MIT"
 
 COPY --from=build /dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm -rf /tmp/*.whl
+# Install with the [connect] extra so BOTH drivers ship in the image: the native
+# clickhouse-driver (default) and the official HTTP clickhouse-connect driver
+# (selected at runtime with --driver clickhouse-connect).
+RUN pip install --no-cache-dir "$(echo /tmp/*.whl)[connect]" && rm -rf /tmp/*.whl
 
 # Mount your migrations here (e.g. `-v $PWD/migrations:/migrations`); the CLI
 # reads this path by default, override with `--migrations-dir` if needed.

--- a/README.md
+++ b/README.md
@@ -169,17 +169,18 @@ Apply migrations from a GitHub workflow with the composite action:
   with:
     migrations-dir: ./migrations
     db-host: localhost
-    db-port: "9000"
     db-user: default
     db-password: ${{ secrets.CLICKHOUSE_PASSWORD }}
     db-name: mydb
-    # or connect via a single URL instead of the db-* inputs:
+    # driver: clickhouse-connect   # optional; official HTTP driver (both are bundled). Defaults to native clickhouse-driver.
+    # db-port: "9000"              # optional; defaults to 9000 (clickhouse-driver) / 8123 (clickhouse-connect)
+    # or connect via a single URL instead of the db-* inputs (clickhouse-driver only):
     # db-url: ${{ secrets.CLICKHOUSE_URL }}
     # any extra raw CLI flags:
     # extra-args: --secure --create-db-if-not-exists
 ```
 
-Inputs: `migrations-dir`, `db-url`, `db-host`, `db-port`, `db-user`, `db-password`, `db-name`, `cluster-name`, `extra-args`, `version` (pin the package version), `python-version`. You can also pin an exact release, e.g. `zifter/clickhouse-migrations@v0.12.0`.
+Both drivers are bundled, so `driver: clickhouse-connect` works without extra setup. Inputs: `migrations-dir`, `db-url`, `db-host`, `db-port`, `db-user`, `db-password`, `db-name`, `cluster-name`, `driver`, `extra-args`, `version` (pin the package version), `python-version`. You can also pin an exact release, e.g. `zifter/clickhouse-migrations@v0.12.0`.
 
 ### With Docker
 
@@ -190,6 +191,15 @@ docker run --rm \
     -v "$PWD/migrations:/migrations" \
     ghcr.io/zifter/clickhouse-migrations:latest \
     --db-url clickhouse://default:secret@clickhouse:9000/mydb
+```
+
+The image bundles **both drivers**. It uses the native `clickhouse-driver` by default; to use the official HTTP `clickhouse-connect` driver, pass `--driver clickhouse-connect` (default port `8123`, and note `--db-url` is `clickhouse-driver` only):
+
+```bash
+docker run --rm \
+    -v "$PWD/migrations:/migrations" \
+    ghcr.io/zifter/clickhouse-migrations:latest \
+    --driver clickhouse-connect --db-host clickhouse --db-name mydb
 ```
 
 Run migrations as a Kubernetes `Job`, e.g. before rolling out a deployment:

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,9 @@ inputs:
     required: false
     default: "localhost"
   db-port:
-    description: "ClickHouse native port"
+    description: "ClickHouse port. Leave empty to use the driver default (9000 for clickhouse-driver, 8123 for clickhouse-connect)."
     required: false
-    default: "9000"
+    default: ""
   db-user:
     description: "ClickHouse user"
     required: false
@@ -37,6 +37,10 @@ inputs:
     description: "ClickHouse cluster name (for ON CLUSTER / replicated deployments)"
     required: false
     default: ""
+  driver:
+    description: "ClickHouse driver: 'clickhouse-driver' (native TCP) or 'clickhouse-connect' (official HTTP). Both are bundled; db-url is clickhouse-driver only."
+    required: false
+    default: "clickhouse-driver"
   extra-args:
     description: "Additional raw CLI arguments, e.g. '--dry-run --secure --create-db-if-not-exists'"
     required: false
@@ -65,9 +69,9 @@ runs:
       run: |
         set -euo pipefail
         if [ -n "$CHM_VERSION" ]; then
-          pip install "clickhouse-migrations==$CHM_VERSION"
+          pip install "clickhouse-migrations[connect]==$CHM_VERSION"
         else
-          pip install clickhouse-migrations
+          pip install "clickhouse-migrations[connect]"
         fi
 
     - name: Apply migrations
@@ -81,14 +85,17 @@ runs:
         CHM_DB_PASSWORD: ${{ inputs.db-password }}
         CHM_DB_NAME: ${{ inputs.db-name }}
         CHM_CLUSTER_NAME: ${{ inputs.cluster-name }}
+        CHM_DRIVER: ${{ inputs.driver }}
         CHM_EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
         set -euo pipefail
-        args=(--migrations-dir "$CHM_MIGRATIONS_DIR")
+        args=(--migrations-dir "$CHM_MIGRATIONS_DIR" --driver "$CHM_DRIVER")
         if [ -n "$CHM_DB_URL" ]; then
           args+=(--db-url "$CHM_DB_URL")
         else
-          args+=(--db-host "$CHM_DB_HOST" --db-port "$CHM_DB_PORT" --db-user "$CHM_DB_USER" --db-password "$CHM_DB_PASSWORD")
+          args+=(--db-host "$CHM_DB_HOST" --db-user "$CHM_DB_USER" --db-password "$CHM_DB_PASSWORD")
+          # Omit --db-port when empty so the tool applies the driver default (9000 / 8123).
+          if [ -n "$CHM_DB_PORT" ]; then args+=(--db-port "$CHM_DB_PORT"); fi
         fi
         if [ -n "$CHM_DB_NAME" ]; then args+=(--db-name "$CHM_DB_NAME"); fi
         if [ -n "$CHM_CLUSTER_NAME" ]; then args+=(--cluster-name "$CHM_CLUSTER_NAME"); fi


### PR DESCRIPTION
## Problem
v0.11 added support for the official `clickhouse-connect` driver, but the two **turnkey** run paths — the published Docker image and the composite GitHub Action — still installed only the native `clickhouse-driver`. Selecting `--driver clickhouse-connect` there failed with:

> The clickhouse-connect driver is not installed. Install it with: `pip install 'clickhouse-migrations[connect]'`

That contradicts the "two drivers" positioning in the README and is exactly the first thing a user coming from the release announcement would hit in CI/Docker.

## Changes
- **Dockerfile** — install the built wheel with the `[connect]` extra, so **both** drivers ship in the image.
- **action.yml** — install `clickhouse-migrations[connect]`; add a `driver` input wired to `--driver`; default `db-port` to empty and pass `--db-port` only when set, so the tool applies the per-driver default (9000 / 8123) and `driver: clickhouse-connect` just works.
- **README** — document both drivers in the Action and Docker sections (with a connect `docker run` example and the new `driver` input).

Backward compatible: the default driver stays `clickhouse-driver`, and omitting `db-port` resolves to 9000 for it (unchanged).

## Verification (built the image locally)
- Both drivers import in the image: `clickhouse_driver 0.2.10 | clickhouse_connect 1.4.1`.
- Default `migrate` path still works (no subcommand): `get_context` prepends `migrate`, and `--driver` is a common arg there.
- `--driver clickhouse-connect` reaches an actual HTTP connection attempt (`clickhouse_connect ... Connection refused`) — i.e. the connect adapter is fully wired, not the "not installed" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)