### PR TITLE
Fix broken Star History chart (self-contained SVG + refresh workflow)

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,42 @@
+name: star-history
+
+# Regenerate the committed star-history chart (assets/star-history.svg) from the
+# GitHub stargazers API. main requires PR review, so instead of pushing directly
+# the job opens a PR whenever the chart changes.
+on:
+  schedule:
+    - cron: "17 3 1 * *" # monthly, 1st at 03:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Regenerate star-history chart
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/gen_star_history.py --repo "${{ github.repository }}" --out assets/star-history.svg
+
+      - name: Open a PR if the chart changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: assets/star-history.svg
+          branch: chore/star-history-refresh
+          delete-branch: true
+          commit-message: "chore: refresh star-history chart"
+          title: "chore: refresh star-history chart"
+          body: |
+            Automated monthly refresh of `assets/star-history.svg` from the GitHub stargazers API.

--- a/README.md
+++ b/README.md
@@ -285,4 +285,6 @@ One important caveat:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zifter/clickhouse-migrations&type=Date)](https://star-history.com/#zifter/clickhouse-migrations&Date)
+[![Star History Chart](assets/star-history.svg)](https://star-history.com/#zifter/clickhouse-migrations&Date)
+
+<sub>Chart is a self-contained SVG (`assets/star-history.svg`) generated from the GitHub API and refreshed by the [`star-history`](.github/workflows/star-history.yml) workflow, so it never breaks when a third-party embed service is rate-limited.</sub>

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif">
+<text x="60" y="24" fill="#7d8590" font-size="15" font-weight="600">Star history — zifter/clickhouse-migrations</text>
+<line x1="60" y1="355.0" x2="770" y2="355.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="359.0" fill="#7d8590" font-size="11" text-anchor="end">0</text>
+<line x1="60" y1="293.0" x2="770" y2="293.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="297.0" fill="#7d8590" font-size="11" text-anchor="end">8</text>
+<line x1="60" y1="231.0" x2="770" y2="231.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="235.0" fill="#7d8590" font-size="11" text-anchor="end">16</text>
+<line x1="60" y1="169.0" x2="770" y2="169.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="173.0" fill="#7d8590" font-size="11" text-anchor="end">24</text>
+<line x1="60" y1="107.0" x2="770" y2="107.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="111.0" fill="#7d8590" font-size="11" text-anchor="end">32</text>
+<line x1="60" y1="45.0" x2="770" y2="45.0" stroke="#7d8590" stroke-opacity="0.2" stroke-width="1"/>
+<text x="52" y="49.0" fill="#7d8590" font-size="11" text-anchor="end">40</text>
+<text x="60.0" y="384" fill="#7d8590" font-size="11" text-anchor="start">Apr 2023</text>
+<text x="415.0" y="384" fill="#7d8590" font-size="11" text-anchor="middle">Nov 2024</text>
+<text x="770.0" y="384" fill="#7d8590" font-size="11" text-anchor="end">Jul 2026</text>
+<polygon points="60.0,355.0 60.0,355.0 60.0,347.2 78.5,339.5 115.1,331.8 151.5,324.0 197.1,316.2 250.8,308.5 291.4,300.8 327.0,293.0 356.9,285.2 385.6,277.5 399.3,269.8 412.4,262.0 414.7,254.2 432.6,246.5 443.3,238.8 487.4,231.0 510.6,223.2 523.8,215.5 538.4,207.8 555.6,200.0 568.9,192.2 580.1,184.5 581.8,176.8 585.4,169.0 653.1,161.2 682.6,153.5 736.3,145.8 758.1,138.0 760.4,130.2 762.1,122.5 764.7,114.8 765.9,107.0 766.7,99.3 767.2,91.5 769.3,83.8 770.0,83.8 770.0,355.0" fill="#539bf5" fill-opacity="0.12"/>
+<polyline points="60.0,355.0 60.0,347.2 78.5,339.5 115.1,331.8 151.5,324.0 197.1,316.2 250.8,308.5 291.4,300.8 327.0,293.0 356.9,285.2 385.6,277.5 399.3,269.8 412.4,262.0 414.7,254.2 432.6,246.5 443.3,238.8 487.4,231.0 510.6,223.2 523.8,215.5 538.4,207.8 555.6,200.0 568.9,192.2 580.1,184.5 581.8,176.8 585.4,169.0 653.1,161.2 682.6,153.5 736.3,145.8 758.1,138.0 760.4,130.2 762.1,122.5 764.7,114.8 765.9,107.0 766.7,99.3 767.2,91.5 769.3,83.8 770.0,83.8" fill="none" stroke="#539bf5" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<text x="770" y="39" fill="#539bf5" font-size="12" font-weight="600" text-anchor="end">35 ★</text>
+</svg>

--- a/scripts/gen_star_history.py
+++ b/scripts/gen_star_history.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate a self-contained star-history SVG from the GitHub API.
+
+Committed as assets/star-history.svg and refreshed by the star-history workflow,
+so the README chart never depends on a third-party embed service at render time.
+
+Usage:
+    GITHUB_TOKEN=$(gh auth token) python scripts/gen_star_history.py \
+        --repo zifter/clickhouse-migrations --out assets/star-history.svg
+"""
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+API = "https://api.github.com"
+
+# Colours chosen to stay legible on both light and dark README backgrounds.
+ACCENT = "#539bf5"
+TEXT = "#7d8590"
+GRID = "#7d8590"
+
+
+def _get(url: str, token: str, accept: str) -> urllib.request.addinfourl:
+    req = urllib.request.Request(url)
+    req.add_header("Accept", accept)
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    return urllib.request.urlopen(req)
+
+
+def fetch_starred_at(repo: str, token: str) -> list:
+    """Return sorted list of datetime objects, one per stargazer."""
+    stars = []
+    page = 1
+    while True:
+        url = f"{API}/repos/{repo}/stargazers?per_page=100&page={page}"
+        with _get(url, token, "application/vnd.github.star+json") as resp:
+            batch = json.load(resp)
+        if not batch:
+            break
+        for item in batch:
+            stars.append(
+                datetime.strptime(item["starred_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc
+                )
+            )
+        if len(batch) < 100:
+            break
+        page += 1
+    stars.sort()
+    return stars
+
+
+def _nice_ceil(value: int) -> int:
+    if value <= 5:
+        return 5
+    step = 10 ** (len(str(value)) - 1)
+    return ((value // step) + 1) * step
+
+
+def _fmt_date(dt: datetime) -> str:
+    return dt.strftime("%b %Y")
+
+
+def render_svg(stars: list, repo: str) -> str:
+    width, height = 800, 400
+    pad_l, pad_r, pad_t, pad_b = 60, 30, 45, 45
+    plot_w = width - pad_l - pad_r
+    plot_h = height - pad_t - pad_b
+
+    now = datetime.now(timezone.utc)
+    total = len(stars)
+
+    # Build cumulative (datetime, count) points. Start the line at the baseline of
+    # the first star so the growth is visible, and extend it flat to "now".
+    if stars:
+        t_min = stars[0]
+        points = [(stars[0], 0)]
+        points += [(dt, i + 1) for i, dt in enumerate(stars)]
+        points.append((now, total))
+    else:
+        t_min = now
+        points = [(now, 0)]
+
+    t_max = now
+    span = (t_max - t_min).total_seconds() or 1.0
+    y_max = _nice_ceil(total)
+
+    def px(dt: datetime) -> float:
+        return pad_l + plot_w * ((dt - t_min).total_seconds() / span)
+
+    def py(count: int) -> float:
+        return pad_t + plot_h * (1 - count / y_max)
+
+    coords = [(px(dt), py(c)) for dt, c in points]
+    line = " ".join(f"{x:.1f},{y:.1f}" for x, y in coords)
+    area = (
+        f"{pad_l:.1f},{pad_t + plot_h:.1f} "
+        + line
+        + f" {coords[-1][0]:.1f},{pad_t + plot_h:.1f}"
+    )
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" '
+        f'font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif">',
+        f'<text x="{pad_l}" y="24" fill="{TEXT}" font-size="15" font-weight="600">'
+        f"Star history — {repo}</text>",
+    ]
+
+    # Y gridlines + labels.
+    y_ticks = 5
+    for i in range(y_ticks + 1):
+        val = round(y_max * i / y_ticks)
+        y = py(val)
+        parts.append(
+            f'<line x1="{pad_l}" y1="{y:.1f}" x2="{pad_l + plot_w}" y2="{y:.1f}" '
+            f'stroke="{GRID}" stroke-opacity="0.2" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{pad_l - 8}" y="{y + 4:.1f}" fill="{TEXT}" font-size="11" '
+            f'text-anchor="end">{val}</text>'
+        )
+
+    # X labels (start, middle, end).
+    for frac in (0.0, 0.5, 1.0):
+        dt = t_min + (t_max - t_min) * frac
+        x = pad_l + plot_w * frac
+        anchor = "start" if frac == 0 else "end" if frac == 1 else "middle"
+        parts.append(
+            f'<text x="{x:.1f}" y="{height - 16}" fill="{TEXT}" font-size="11" '
+            f'text-anchor="{anchor}">{_fmt_date(dt)}</text>'
+        )
+
+    parts.append(f'<polygon points="{area}" fill="{ACCENT}" fill-opacity="0.12"/>')
+    parts.append(
+        f'<polyline points="{line}" fill="none" stroke="{ACCENT}" '
+        f'stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>'
+    )
+    parts.append(
+        f'<text x="{pad_l + plot_w}" y="{pad_t - 6}" fill="{ACCENT}" font-size="12" '
+        f'font-weight="600" text-anchor="end">{total} ★</text>'
+    )
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default="zifter/clickhouse-migrations")
+    parser.add_argument("--out", default="assets/star-history.svg")
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    try:
+        stars = fetch_starred_at(args.repo, token)
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network guard
+        print(f"GitHub API error: {exc}")
+        return 1
+
+    svg = render_svg(stars, args.repo)
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf8") as handle:
+        handle.write(svg)
+    print(f"Wrote {args.out} ({len(stars)} stars)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

The README **Star History** chart used `api.star-history.com`, whose free/shared GitHub API tokens are frequently rate-limited:

```
$ curl -s "https://api.star-history.com/svg?repos=zifter/clickhouse-migrations&type=Date"
All GitHub API tokens are rate-limited, try again later   # HTTP 503
```

GitHub's image proxy then shows a broken image. (`starchart.cc` has the same failure mode.)

## Fix

- **`assets/star-history.svg`** — the chart is now a self-contained SVG generated from the GitHub stargazers API and committed to the repo. No third-party embed at render time → it can't break. Theme-agnostic colours (readable on light and dark).
- **`scripts/gen_star_history.py`** — pure-stdlib generator (`GITHUB_TOKEN=$(gh auth token) python scripts/gen_star_history.py`).
- **`.github/workflows/star-history.yml`** — monthly (+ manual) job that regenerates the SVG and opens a PR when it changed. `main` requires PR review, so the bot opens a PR instead of pushing directly.
- README now points at the committed SVG; the interactive [star-history.com](https://star-history.com/#zifter/clickhouse-migrations&Date) link is kept.

## One-time setting for the auto-refresh

For the workflow to open its PR with the built-in `GITHUB_TOKEN`, enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**. Without it the scheduled job just fails harmlessly — the committed chart still renders, and it can be refreshed manually with the script any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
